### PR TITLE
Fix http / https protocol requirement.

### DIFF
--- a/controller/lib/bookmarks.php
+++ b/controller/lib/bookmarks.php
@@ -426,11 +426,12 @@ class Bookmarks {
 	 */
 	public static function addBookmark($userid, IDb $db, $url, $title, $tags = array(), $description = '', $is_public = false) {
 		$public = $is_public ? 1 : 0;
-		$enc_url = htmlspecialchars_decode($url);
+		$url_without_prefix = substr($url, strpos($url, "://") + 3); // Removes everything from the url before the "://" pattern (included)
+		$enc_url = htmlspecialchars_decode($url_without_prefix);
 		// Change lastmodified date if the record if already exists
-		$sql = "SELECT * from  `*PREFIX*bookmarks` WHERE `url` = ? AND `user_id` = ?";
+		$sql = "SELECT * from  `*PREFIX*bookmarks` WHERE `url` like ? AND `user_id` = ?";
 		$query = $db->prepareQuery($sql, 1);
-		$result = $query->execute(array($enc_url, $userid));
+		$result = $query->execute(array('%'.$enc_url, $userid)); // Find url in the db independantly from its protocol
 		if ($row = $result->fetchRow()) {
 			$params = array();
 			$title_str = '';

--- a/controller/lib/bookmarks.php
+++ b/controller/lib/bookmarks.php
@@ -427,11 +427,12 @@ class Bookmarks {
 	public static function addBookmark($userid, IDb $db, $url, $title, $tags = array(), $description = '', $is_public = false) {
 		$public = $is_public ? 1 : 0;
 		$url_without_prefix = substr($url, strpos($url, "://") + 3); // Removes everything from the url before the "://" pattern (included)
-		$enc_url = htmlspecialchars_decode($url_without_prefix);
+		$enc_url_noprefix = htmlspecialchars_decode($url_without_prefix);
+		$enc_url = htmlspecialchars_decode($url);
 		// Change lastmodified date if the record if already exists
 		$sql = "SELECT * from  `*PREFIX*bookmarks` WHERE `url` like ? AND `user_id` = ?";
 		$query = $db->prepareQuery($sql, 1);
-		$result = $query->execute(array('%'.$enc_url, $userid)); // Find url in the db independantly from its protocol
+		$result = $query->execute(array('%'.$enc_url_noprefix, $userid)); // Find url in the db independantly from its protocol
 		if ($row = $result->fetchRow()) {
 			$params = array();
 			$title_str = '';
@@ -445,8 +446,9 @@ class Bookmarks {
 				$params[] = $description;
 			}
 			$sql = "UPDATE `*PREFIX*bookmarks` SET `lastmodified` = "
-					. "UNIX_TIMESTAMP() $title_str $desc_str WHERE `url` = ? and `user_id` = ?";
+					. "UNIX_TIMESTAMP() $title_str $desc_str , `url` = ? WHERE `url` like ? and `user_id` = ?";
 			$params[] = $enc_url;
+			$params[] = '%'.$enc_url_noprefix;
 			$params[] = $userid;
 			$query = $db->prepareQuery($sql);
 			$query->execute($params);

--- a/controller/rest/bookmarkcontroller.php
+++ b/controller/rest/bookmarkcontroller.php
@@ -70,7 +70,7 @@ class BookmarkController extends ApiController {
 
 		if ($from_own == 0) {
 			// allow only http(s) and (s)ftp
-			$protocols = '/^[hs]{0,1}[tf]{0,1}tp[s]{0,1}\:\/\//i';
+			$protocols = '/^(https?|s?ftp)\:\/\//i';
 			if (preg_match($protocols, $url)) {
 				$datas = Bookmarks::getURLMetadata($url);
 			// if not (allowed) protocol is given, assume http and https (and fetch both)

--- a/controller/rest/bookmarkcontroller.php
+++ b/controller/rest/bookmarkcontroller.php
@@ -71,8 +71,10 @@ class BookmarkController extends ApiController {
 		if ($from_own == 0) {
 			// allow only http(s) and (s)ftp
 			$protocols = '/^[hs]{0,1}[tf]{0,1}tp[s]{0,1}\:\/\//i';
+			if (preg_match($protocols, $url)) {
+				$datas = Bookmarks::getURLMetadata($url);
 			// if not (allowed) protocol is given, assume http and https (and fetch both)
-			if (! preg_match($protocols, $url)) {
+			} elseif (! preg_match($protocols, $url)) { 
 				// append https to url and fetch it
 				$url_https = 'https://' . $url;
 				$datas_https = Bookmarks::getURLMetadata($url_https);
@@ -80,8 +82,11 @@ class BookmarkController extends ApiController {
 				$url_http = 'http://' . $url;
 				$datas_http = Bookmarks::getURLMetadata($url_http);
 			}
-			// adopt https if it works (switch to http if it doesn't)
-			if (isset($datas_https['title'])) { // test if https works
+			
+			if (isset($datas['title'])) { // prefer original url if working
+				$title = $datas['title'];
+				//url remains unchanged
+			} elseif (isset($datas_https['title'])) { // test if https works
 				$title = $datas_https['title'];
 				$url = $url_https;
 			} elseif (isset($datas_http['title'])) { // otherwise test http for results

--- a/controller/rest/bookmarkcontroller.php
+++ b/controller/rest/bookmarkcontroller.php
@@ -74,7 +74,7 @@ class BookmarkController extends ApiController {
 			if (preg_match($protocols, $url)) {
 				$datas = Bookmarks::getURLMetadata($url);
 			// if not (allowed) protocol is given, assume http and https (and fetch both)
-			} elseif (! preg_match($protocols, $url)) { 
+			} else { 
 				// append https to url and fetch it
 				$url_https = 'https://' . $url;
 				$datas_https = Bookmarks::getURLMetadata($url_https);


### PR DESCRIPTION
Trying to fix issue #113

Fix the http / https prefix requirement when adding a bookmark without prefix by :
1 - Constructing URLs for both protocols,
2 - Retrieving both pages titles,
3 - Choosing the one which works, with a systematic preference for https.

I'd be glad to hear from anyone about several things to discuss :
- I have choosed to always test for the original submitted url, the submitted url with http prefix, and the submitted url with https prefix, but I don't know if that is the best way to achieve tests,
- What about the original (s)ftp bookmark support ? Do you think it is worth keeping it ? in such case, wouldn't it be a bit stupid and heavy to always retrieve each possible page to test each protocol ?
- Should users have their bookmark links always enforced to https if the remote server supports https ? I have currently choosed to respect user's input when they specify a protocol : if you input http://github.com, the bookmark will respect your choice and won't switch to https..
- Problem : In case where https has been implemented on the remote server but the website is not properly configured to work with it, it can end-up obtaining "403 Forbidden" bookmarks titles (experiment it by adding "lefigaro.fr" as bookmark).

Great thanks in advance for sharing your thoughts !! :)