### PR TITLE
Adding tags in bookmarklet, fix #127

### DIFF
--- a/controller/webviewcontroller.php
+++ b/controller/webviewcontroller.php
@@ -48,11 +48,19 @@ class WebViewController extends Controller {
 	public function bookmarklet($url = "", $title = "") {
 		$bookmarkExists = Bookmarks::bookmarkExists($url, $this->userId, $this->db);
 		$description = "";
+        $tags = [];
 		if ($bookmarkExists != false){
 			$bookmark = Bookmarks::findUniqueBookmark($bookmarkExists, $this->userId, $this->db);
 			$description = $bookmark['description'];
+            $tags = $bookmark['tags'];
 		}
-		$params = array('url' => $url, 'title' => $title, 'description' => $description, 'bookmarkExists' => $bookmarkExists);
+		$params = array(
+            'url'           => $url,
+            'title'         => $title,
+            'description'   => $description,
+            'bookmarkExists'=> $bookmarkExists,
+            'tags'          => $tags
+        );
 		return new TemplateResponse('bookmarks', 'addBookmarklet', $params);  // templates/main.php
 	}
 

--- a/js/bookmarklet.js
+++ b/js/bookmarklet.js
@@ -25,8 +25,12 @@ function updateLoadingAnimation() {
 $(function () {
 	$(".submit").click(function () {
 		increaseAjaxCallCount();
-		var dataString = 'url=' + $("input#url").val() + '&description=' +
-				$("textarea#description").val() + '&title=' + $("input#title").val();
+        var tags = '';
+        $('.tagit-choice .tagit-label').each(function() {
+            tags += '&item[tags][]='+$(this).text();
+        });
+        var dataString = 'url=' + $("input#url").val() + '&description=' +
+            $("textarea#description").val() + '&title=' + $("input#title").val() + tags;
 		$.ajax({
 			type: "POST",
 			url: "bookmark",
@@ -48,6 +52,13 @@ $(function () {
 		});
 		return false;
 	});
+    $.get('tag', function(data) {
+        $('.tags').tagit({
+            allowSpaces: true,
+            availableTags : data,
+            placeholderText: t('bookmark', 'Tags')
+        });
+    });
 });
 
 function closeWindow() {

--- a/templates/addBookmarklet.php
+++ b/templates/addBookmarklet.php
@@ -35,9 +35,9 @@ $bookmarkExists = $_['bookmarkExists'];
 
                 <li>
                     <ul class="tags" >
-						<?php foreach ($_['bookmark']['tags'] as $tag): ?>
-							<li><?php p($tag); ?></li>
-						<?php endforeach; ?>
+                        <ul class="tags" >
+                            <li></li>
+                        </ul>
                     </ul>
                 </li>
 

--- a/templates/addBookmarklet.php
+++ b/templates/addBookmarklet.php
@@ -1,6 +1,8 @@
 <?php
+OCP\Util::addscript('bookmarks', '3rdparty/tag-it');
 OCP\Util::addscript('bookmarks', 'bookmarklet');
 OCP\Util::addStyle('bookmarks', 'bookmarks');
+OCP\Util::addStyle('bookmarks', '3rdparty/jquery.tagit');
 
 $bookmarkExists = $_['bookmarkExists'];
 ?>

--- a/templates/addBookmarklet.php
+++ b/templates/addBookmarklet.php
@@ -34,10 +34,10 @@ $bookmarkExists = $_['bookmarkExists'];
                 </li>
 
                 <li>
-                    <ul class="tags" >
-                        <ul class="tags" >
-                            <li></li>
-                        </ul>
+                    <ul id="tags" class="tags" >
+                        <?php foreach ($_['tags'] as $tag): ?>
+                            <li><?php p($tag); ?></li>
+                        <?php endforeach; ?>
                     </ul>
                 </li>
 


### PR DESCRIPTION
tags weren't given to the view. 
In 7.0, you had a `full_tags.php` which generated a js array with it. 
Now it seems to be an API call to "tag".
So I did an ajax call to get all current user tags and then initiate the `tagit` plugin.

The `$_['bookmark']` array wasn't nourished anymore so I removed it. Don't know what it was for, please, tell me, I'm sure it was for something.

Finally, in 7.0, when you submitted the form, there was a `$(this).serialize()` done on it to pass the data. Anyway, it seemed not to work anymore (tags weren't send at all :-1: ) So, I parsed them myself.