### PR TITLE
init req_tag variable at app startup fix #126

### DIFF
--- a/controller/webviewcontroller.php
+++ b/controller/webviewcontroller.php
@@ -37,7 +37,7 @@ class WebViewController extends Controller {
 	 */
 	public function index() {
 		$bookmarkleturl = $this->urlgenerator->getAbsoluteURL('index.php/apps/bookmarks/bookmarklet');
-		$params = array('user' => $this->userId, 'bookmarkleturl' => $bookmarkleturl);
+		$params = array('user' => $this->userId, 'bookmarkleturl' => $bookmarkleturl, 'req_tag'=>'');
 		return new TemplateResponse('bookmarks', 'main', $params);
 	}
 


### PR DESCRIPTION
In stable7, `req_tag` was initialized by '' or `$_GET['tag']` : https://github.com/owncloud/bookmarks/blob/stable7/index.php#L41

The lack of initialization gives error as statued in #126 

This PR initializes `req_tag` to `''` (since I don't know how to had a get parameter in OC8). It's modified then by user thanks to my previous PR #133 