### PR TITLE
Use the title in the input field when adding new bookmark

### DIFF
--- a/controller/rest/bookmarkcontroller.php
+++ b/controller/rest/bookmarkcontroller.php
@@ -84,13 +84,13 @@ class BookmarkController extends ApiController {
 			}
 			
 			if (isset($datas['title'])) { // prefer original url if working
-				$title = $datas['title'];
+				//use title from input field, more accurate $title = $datas['title'];
 				//url remains unchanged
 			} elseif (isset($datas_https['title'])) { // test if https works
-				$title = $datas_https['title'];
+				//use title from input field, more accurate $title = $datas_https['title'];
 				$url = $url_https;
 			} elseif (isset($datas_http['title'])) { // otherwise test http for results
-				$title = $datas_http['title'];
+				//use title from input field, more accurate $title = $datas_http['title'];
 				$url = $url_http;
 			}
 		}


### PR DESCRIPTION
The Original title already got queried and put into the input field. If the user doesn't change it, it will be saved. If the user changes it, he wants it to be changed and not queried again from the original site.

BTW: If a page has two "title" lines, getURLMetadata is too greedy and queries everything from first <title> to the last </title>
You can test that behavior with http://www.metasploitation.com/

This refers to bug https://github.com/owncloud/bookmarks/issues/29

Cheers,

Erik