### PR TITLE
[stable7] fix add button to show in same line as input field

### DIFF
--- a/css/bookmarks.css
+++ b/css/bookmarks.css
@@ -83,16 +83,29 @@ input.disabled, input.disabled:hover, input.disabled:focus {
 	right:0;
 }
 
-#add_form {
-	padding-bottom: 2em;
+#add_form_loading {
+	visibility: hidden;
+	position: absolute;
+	top: 11px;
+	right: 17%;
 }
 
-#add_form input {
+#add_form_input {
 	margin: 0.3em;
 }
+
 #add_url {
-	width: 12em;
+    box-sizing: border-box
+	width: 91.5%;
+    padding-right: 15%;
 }
+#bookmark_add_submit {
+    position: absolute;
+    top: 0;
+    right: 0;
+    height: 31px;
+}
+
 .bookmarks_addBml {
 	text-decoration: underline;
 }


### PR DESCRIPTION
Conflicts:
	css/bookmarks.css

@jancborchardt I took your commit https://github.com/owncloud/bookmarks/commit/61f95f2a7944cc44f8ac8a5caea59b5cbff44b18 from #119 and based it off stable7 again. 

Looks now like:


![screenshot1](https://cloud.githubusercontent.com/assets/2184312/8595610/f164222c-2649-11e5-913f-27963ee7ff43.jpg)

Is it as intended?



(For reference, without this:

![before](https://cloud.githubusercontent.com/assets/2184312/8595460/598e5ec2-2649-11e5-95eb-6d3eacc0a963.jpg)

)

