### PR TITLE
[BUGGED!] Added CRUD actions for REST API

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -38,7 +38,10 @@ $application->registerRoutes($this, array('routes' => array(
 		array('name' => 'tags#rename_tag', 'url' => '/tag', 'verb' => 'POST'),
 		array('name' => 'tags#delete_tag', 'url' => '/tag', 'verb' => 'DELETE'),
 		//Public Rest Api
-		array('name' => 'public#return_as_json', 'url' => '/public/rest/v1/bookmark', 'verb' => 'GET'),
+		array('name' => 'public#get', 'url' => '/public/rest/v1/bookmarks', 'verb' => 'GET'),
+		array('name' => 'public#add', 'url' => '/public/rest/v1/bookmarks', 'verb' => 'POST'),
+		array('name' => 'public#update', 'url' => '/public/rest/v1/bookmarks/{id}', 'verb' => 'PUT'),
+		array('name' => 'public#delete', 'url' => '/public/rest/v1/bookmarks/{id}', 'verb' => 'DELETE'),
 		//Legacy Routes
 		array('name' => 'bookmark#legacy_get_bookmarks', 'url' => '/ajax/updateList.php', 'verb' => 'POST'),
 		array('name' => 'bookmark#legacy_edit_bookmark', 'url' => '/ajax/editBookmark.php', 'verb' => 'POST'),

--- a/controller/rest/publiccontroller.php
+++ b/controller/rest/publiccontroller.php
@@ -23,12 +23,13 @@ class PublicController extends ApiController {
 	}
 
 	/**
+	 * Return all or selected bookmarks
 	 * @CORS
 	 * @NoAdminRequired
 	 * @NoCSRFRequired
 	 * @PublicPage
 	 */
-	public function returnAsJson($user, $password = null, $tags = array(), $conjunction = "or", $select = null, $sortby = "") {
+	public function get($user, $password = null, $tags = array(), $conjunction = "or", $select = null, $sortby = "") {
 
 		if ($user == null || $this->userManager->userExists($user) == false) {
 			return $this->newJsonErrorMessage("User could not be identified");
@@ -63,15 +64,104 @@ class PublicController extends ApiController {
 		$output = Bookmarks::findBookmarks($user, $this->db, 0, $sortby, $tags, true, -1, $public, $attributesToSelect, $conjunction);
 
 		if (count($output) == 0) {
-			$output["status"] = 'error';
-			$output["message"] = "No results from this query";
-			return new JSONResponse($output);
+			return $this->newJsonErrorMessage("No results from this query");
 		}
 
 		return new JSONResponse($output);
 	}
 
-	public function newJsonErrorMessage($message) {
+
+        /**
+         * Add new bookmark
+         * @CORS
+         * @NoAdminRequired
+         * @NoCSRFRequired
+         * @PublicPage
+         */
+	public function add($user = null, $password = null, $url = '', $title = '', $tags = array(), $description= '', $is_public = false)
+	{
+		if(!$this->isUser($user,$password))
+		{
+                        return $this->newJsonErrorMessage("User could not be identified");
+		}
+
+		$bookmark_id = Bookmarks::addBookmark($user, $this->db, $url, $title, $tags, $description, $is_public);
+		
+		if($bookmark_id)
+		{
+			$output = array();
+			$output["status"] = "ok";
+			$output["message"] = $bookmark_id;
+			
+			return new JSONResponse($output);
+		}else{
+			return $this->newJsonErrorMessage("Something wrong. Bookmark hasn't been added.");
+		}
+	}
+
+	public function update($user = null, $password = null, $id = null, $url, $title, $tags = array(), $description, $is_public = false)
+	{
+		if(!$this->isUser($user, $password))
+		{
+			return $this->newJsonErrorMessage("User could not be identified");
+		}
+
+		Bookmarks::editBookmark($user,$this->db, $id, $url, $title, $tags, $description, $is_public);
+
+		return new JSONResponse(array('status' => 'ok', 'message' => 'Bookmark has been updated. I hope.'));
+		
+	}
+
+	/**
+         * Remove bookmark
+         * @CORS
+         * @NoAdminRequired
+         * @NoCSRFRequired
+         * @PublicPage
+         */
+        public function delete($user = null, $password = null, $id = null)
+        {
+                if(!$this->isUser($user,$password))
+                {
+                        return $this->newJsonErrorMessage("User could not be identified");
+                }
+
+                $result = Bookmarks::deleteUrl($user, $this->db, $id);
+
+                if($result)
+                {
+                        $output = array();
+                        $output["status"] = "ok";
+                        $output["message"] = "Bookmark has been deleted.";
+
+                        return new JSONResponse($output);
+                }else{
+                        return $this->newJsonErrorMessage("Something wrong. Bookmark hasn't been deleted.");
+                }
+        }
+
+	/**
+	 * Check if user exists
+	 * @param string $user username
+	 * @param string $password user password
+	 * @return bool
+	 */
+	private function isUser($user, $password)
+	{
+		if (!$user || $this->userManager->userExists($user) == false) {
+                        return false;
+                }elseif(!$this->userManager->checkPassword($user, $password)) {
+
+                        $msg = 'REST API accessed with wrong password';
+                        \OCP\Util::writeLog('bookmarks', $msg, \OCP\Util::WARN);
+
+			return false;
+                }else{
+			return true;
+		}
+	}
+
+	private function newJsonErrorMessage($message) {
 		$output = array();
 		$output["status"] = 'error';
 		$output["message"] = $message;


### PR DESCRIPTION
Hello!
Please, help me with some... bug(?). In public controller I wrote following code:
```php
<?php
public function update($user = null, $password = null, $id = null, $url, $title, $tags = array(), $description, $is_public = false)
        {
                if(!$this->isUser($user, $password))
                {
                        return $this->newJsonErrorMessage("User could not be identified");
                }

                Bookmarks::editBookmark($user,$this->db, $id, $url, $title, $tags, $description, $is_public);

                return new JSONResponse(array('status' => 'ok', 'message' => 'Bookmark has been updated. I hope.'));

        }
```

And added the following in routes.php:
```php
<?php
array('name' => 'public#update', 'url' => '/public/rest/v1/bookmarks/{id}', 'verb' => 'PUT')
```

But when I try to do request (all data correct), I got following message: 
```json
{
  "message": "Current user is not logged in"
}
```
and HTTP status code 401. Explain please, what I doing wrong?

Thank you!

pS: API will be ready after fix of this problem. For now, it works only with bookmarks. No tags available now.