### PR TITLE
work around filter_vars limitation with unicode chars in the URL

### DIFF
--- a/controller/lib/helper.php
+++ b/controller/lib/helper.php
@@ -13,4 +13,30 @@ class Helper {
 		}
 	}
 
+	/**
+	 * fake-encodes a URL so filter_var($url, FILTER_VALIDATE_URL) would not
+	 * stumble over non-ascii characters
+	 *
+	 * @param array $urlData as received from parse_url
+	 * @return string
+	 * @link https://php.net/manual/en/function.parse-url.php#106731
+	 */
+	static function fakeEncodeUrl(array $urlData) {
+		$urlData['path'] = implode('/', array_map(function($part) {
+			return rawurlencode($part);
+		}, explode('/', $urlData['path'])));
+
+		$scheme   = isset($urlData['scheme'])   ? rawurlencode($urlData['scheme']) . '://' : '';
+		$host     = isset($urlData['host'])     ? rawurlencode($urlData['host']) : '';
+		$port     = isset($urlData['port'])     ? ':' . $urlData['port'] : '';
+		$user     = isset($urlData['user'])     ? rawurlencode($urlData['user']) : '';
+		$pass     = isset($urlData['pass'])     ? ':' . rawurlencode($urlData['pass'])  : '';
+		$pass     = ($user || $pass)            ? "$pass@" : '';
+		$path     = isset($urlData['path'])     ? $urlData['path'] : '';
+		$query    = isset($urlData['query'])    ? '?' . rawurlencode($urlData['query']) : '';
+		$fragment = isset($urlData['fragment']) ? '#' . rawurlencode($urlData['fragment']) : '';
+
+		return "$scheme$user$pass$host$port$path$query$fragment";
+	}
+
 }

--- a/controller/rest/bookmarkcontroller.php
+++ b/controller/rest/bookmarkcontroller.php
@@ -12,6 +12,7 @@
 
 namespace OCA\Bookmarks\Controller\Rest;
 
+use OCA\Bookmarks\Controller\Lib\Helper;
 use \OCP\IRequest;
 use \OCP\AppFramework\ApiController;
 use \OCP\AppFramework\Http\JSONResponse;
@@ -96,7 +97,15 @@ class BookmarkController extends ApiController {
 		}
 
 		// Check if it is a valid URL (after adding http(s) prefix)
-		if (filter_var($url, FILTER_VALIDATE_URL) === FALSE) {
+		$testUrl = $url;
+		if(strlen($url) !== mb_strlen($url)) {
+			$urlData = parse_url($url);
+			if($urlData === false) {
+				return new JSONResponse(array('status' => 'error'), Http::STATUS_BAD_REQUEST);
+			}
+			$testUrl = Helper::fakeEncodeUrl($urlData);
+		}
+		if (filter_var($testUrl, FILTER_VALIDATE_URL) === FALSE) {
 			return new JSONResponse(array('status' => 'error'), Http::STATUS_BAD_REQUEST);
 		}
 


### PR DESCRIPTION
1. Go to https://de.wikipedia.org/wiki/%C3%84
2. Try to add it to bookmarks via bookmarklet

Currently it will fail silently, a 400 error is returned. It's because filter_var is used for URL verification, alas it returns false if URLs contain non-ascii characters. This works around it, yet i am not sure it's the best solution, only the first that came to my mind. Of course, it's ugly, but better than https://secure.php.net/manual/en/function.filter-var.php#104160.