### PR TITLE
[8.2] backport of #240

### DIFF
--- a/controller/rest/bookmarkcontroller.php
+++ b/controller/rest/bookmarkcontroller.php
@@ -96,7 +96,8 @@ class BookmarkController extends ApiController {
 		}
 
 		// Check if it is a valid URL (after adding http(s) prefix)
-		if (filter_var($url, FILTER_VALIDATE_URL) === FALSE) {
+		$urlData = parse_url($url);
+		if ($urlData === false || !isset($urlData['scheme']) || !isset($urlData['host'])) {
 			return new JSONResponse(array('status' => 'error'), Http::STATUS_BAD_REQUEST);
 		}
 
@@ -133,7 +134,8 @@ class BookmarkController extends ApiController {
 	public function editBookmark($id = null, $url = "", $item = array(), $title = "", $is_public = false, $record_id = null, $description = "") {
 
 		// Check if it is a valid URL
-		if (filter_var($url, FILTER_VALIDATE_URL) === FALSE) {
+		$urlData = parse_url($url);
+		if ($urlData === false || !isset($urlData['scheme']) || !isset($urlData['host'])) {
 			return new JSONResponse(array(), Http::STATUS_BAD_REQUEST);
 		}
 
@@ -190,7 +192,8 @@ class BookmarkController extends ApiController {
 	public function clickBookmark($url = "") {
 
 		// Check if it is a valid URL
-		if (filter_var($url, FILTER_VALIDATE_URL) === FALSE) {
+		$urlData = parse_url($url);
+		if ($urlData === false || !isset($urlData['scheme']) || !isset($urlData['host'])) {
 			return new JSONResponse(array(), Http::STATUS_BAD_REQUEST);
 		}
 

--- a/tests/lib_bookmark_test.php
+++ b/tests/lib_bookmark_test.php
@@ -17,8 +17,10 @@ class Test_LibBookmarks_Bookmarks extends PHPUnit_Framework_TestCase {
 	function testAddBookmark() {
 		$this->cleanDB();
 		$this->assertCount(0, Bookmarks::findBookmarks($this->userid, $this->db, 0, 'id', array(), true, -1));
-		Bookmarks::addBookmark($this->userid, $this->db, 'http://owncloud.org', 'Owncloud project', array('oc', 'cloud'), 'An Awesome project');
+		Bookmarks::addBookmark($this->userid, $this->db, 'http://owncloud.org', 'owncloud project', array('oc', 'cloud'), 'An Awesome project');
 		$this->assertCount(1, Bookmarks::findBookmarks($this->userid, $this->db, 0, 'id', array(), true, -1));
+		Bookmarks::addBookmark($this->userid, $this->db, 'http://de.wikipedia.org/Ü', 'Das Ü', array('encyclopedia', 'lang'), 'A terrific letter');
+		$this->assertCount(2, Bookmarks::findBookmarks($this->userid, $this->db, 0, 'id', array(), true, -1));
 	}
 
 	function testFindBookmarks() {


### PR DESCRIPTION
use parse_url to verify dn, because filter_var has issues with special chars

Add test on adding bookmark with URL containing umlaut

Does not relate to this issue (different code path, not covered by tests
yet), but still it is a good addition.