### PR TITLE
Restore broken tag selection functionality

### DIFF
--- a/css/3rdparty/jquery.tagit.css
+++ b/css/3rdparty/jquery.tagit.css
@@ -3,6 +3,7 @@ ul.tagit {
 	overflow: auto;
     margin-left: inherit; /* usually we don't want the regular ul margins. */
     margin-right: inherit;
+    width: 91.5%;
 }
 ul.tagit li {
 	display: block;

--- a/css/bookmarks.css
+++ b/css/bookmarks.css
@@ -263,6 +263,7 @@ li:hover > .tags_actions > em { display : none; }
 }
 
 #tag_filter a {
+    display: inline-block;
     display: inline;
     float: none;
     margin: 0;

--- a/css/bookmarks.css
+++ b/css/bookmarks.css
@@ -251,6 +251,7 @@ li:hover > .tags_actions > em { display : none; }
     background: none repeat scroll 0 0 #F8F8F8;
 }
 #tag_filter .tagit {
+    display: inline-block;
     margin: 0.3em;
 }
 #tag_filter ul.tagit > li.tagit-new {
@@ -263,7 +264,6 @@ li:hover > .tags_actions > em { display : none; }
 }
 
 #tag_filter a {
-    display: inline-block;
     display: inline;
     float: none;
     margin: 0;

--- a/js/3rdparty/tag-it.js
+++ b/js/3rdparty/tag-it.js
@@ -323,7 +323,7 @@
 			this._tagInput.val('');
 
 			// insert tag
-			this._tagInput.parent().before(tag);
+			this._tagInput.parent().after(tag);
 		},
 		removeTag: function (tag, animate) {
 			if (typeof animate === 'undefined') {


### PR DESCRIPTION
Hello @blizzz @jancborchardt @Chouchen :)

I am opening this very very small PR in order to fix the current Bookmarks app tag filtering function.

I know and agree the fact that we can (and should) change many many things regarding the OC Bookmarks tag selection behavior and layout (https://github.com/owncloud/bookmarks/issues/118, https://github.com/owncloud/bookmarks/pull/219). 
However, given that the bookmark app development activity is unfortunately extremely low at the moment, one of our top priorities _should be_ to ensure that it _mostly_ works and that there are no main bugs or broken functionalities (e.g.: filter only with 1 tag + need to reload the page to restore the original tag list https://github.com/owncloud/bookmarks/issues/168).

It's quite sad/hard to realise that some basic bookmark app functionalities have been kind of left in a broken state for many months now and that things are not changing. 

This PR contains the minimal amount of code needed to restore the tag selection functionality. I've juste realised that Chouchen wrote an even more basic fix (https://github.com/owncloud/bookmarks/pull/133) 6 months ago but that it has still not been merged.

I understand the need and discussions to improve the tag selection but ... let's fix it first in order to provide every new OC user with a working Bookmarks app version, and then see later on how we will be able to improve it even more !! ? :)

Please let me know your thoughts on this and also if the fix is OK for you ! :)